### PR TITLE
Add LERNA_PACKAGE_VERSION variable

### DIFF
--- a/commands/exec/__tests__/exec-command.test.js
+++ b/commands/exec/__tests__/exec-command.test.js
@@ -105,9 +105,11 @@ describe("ExecCommand", () => {
         cwd: path.join(testDir, "packages/package-2"),
         pkg: expect.objectContaining({
           name: "package-2",
+          version: "1.2.3"
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: "package-2",
+          LERNA_PACKAGE_VERSION: "1.2.3",
           LERNA_ROOT_PATH: testDir,
         }),
         extendEnv: false,

--- a/commands/exec/__tests__/exec-command.test.js
+++ b/commands/exec/__tests__/exec-command.test.js
@@ -105,11 +105,11 @@ describe("ExecCommand", () => {
         cwd: path.join(testDir, "packages/package-2"),
         pkg: expect.objectContaining({
           name: "package-2",
-          version: "1.2.3"
+          version: "1.0.0"
         }),
         env: expect.objectContaining({
           LERNA_PACKAGE_NAME: "package-2",
-          LERNA_PACKAGE_VERSION: "1.2.3",
+          LERNA_PACKAGE_VERSION: "1.0.0",
           LERNA_ROOT_PATH: testDir,
         }),
         extendEnv: false,

--- a/commands/exec/index.js
+++ b/commands/exec/index.js
@@ -113,6 +113,7 @@ class ExecCommand extends Command {
       extendEnv: false,
       env: Object.assign({}, this.env, {
         LERNA_PACKAGE_NAME: pkg.name,
+        LERNA_PACKAGE_VERSION: pkg.version,
         LERNA_ROOT_PATH: this.project.rootPath,
       }),
       reject: this.bail,

--- a/integration/lerna-exec.test.js
+++ b/integration/lerna-exec.test.js
@@ -88,6 +88,21 @@ package-2
 `);
 });
 
+test("lerna exec echo $LERNA_PACKAGE_VERSION", async () => {
+  const args = [
+    "exec",
+    "--concurrency=1",
+    "echo",
+    process.platform === "win32" ? "%LERNA_PACKAGE_VERSION%" : "$LERNA_PACKAGE_VERSION",
+  ];
+
+  const { stdout } = await cliRunner(cwd)(...args);
+  expect(stdout).toMatchInlineSnapshot(`
+1.0.0
+1.0.0
+`);
+});
+
 test("lerna exec --parallel", async () => {
   const args = [
     "exec",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add LERNA_PACKAGE_VERSION to work alongside LERNA_PACKAGE_NAME

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to be able to tag the current version of all the packages in my monorepo separately from publish.
I presume this will also help some inline scripting use cases, since it's very difficult to get a the package version cleanly.
`npm pkg get version` prints out the version as JSON "1.0.0" so you have to strip the quotes.
or alternatively `npm run env -s echo '$npm_package_version'`

Unfortunately, writing complex scripts with lerna exec just doesn't work.  (i.e. those that have embedded script execution that requires single quotes or double quotes within):
```
for DIR in $(npm exec -- lerna list --parseable --toposort); do
  PACKAGE=$(npm run env -s echo '$npm_package_name@$npm_package_version')
  npm dist-tag add $PACKAGE my-tag
fi
```

Now i can turn my for-loop into
`lerna exec npm dist-tag add \$LERNA_PACKAGE_NAME@\$LERNA_PACKAGE_VERSION my-tag`

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
